### PR TITLE
oDBO should expect absolute paths

### DIFF
--- a/src/oDBOStatement.php
+++ b/src/oDBOStatement.php
@@ -102,7 +102,7 @@ class oDBOStatement
             if (is_array($param)) {
                 $this->bindArray($key, $param);
             } else {
-                $this->bindValues($key, $param);
+                $this->bindValue($key, $param);
             }
         }
     }
@@ -255,7 +255,7 @@ class oDBOStatement
      * Load SQL
      *  Loads an SQL File from the data layer directory (/data/your/filepath/here.sql)
      *
-     * @param string $file sql file path relative to the root 'data' directory (i.e. 'orders/oShipments/select_shipments.sql')
+     * @param string $file absolute sql file path
      *
      * @throws SqlFileNotFoundException
      * @throws SqlFileFailedToLoadException
@@ -264,7 +264,7 @@ class oDBOStatement
      **/
     protected function loadSqlFile($file)
     {
-        $file = preg_replace('#/+#', '/', 'data/' . $file);
+        $file = preg_replace('#/+#', '/', $file);
 
         /*
         -- TODO --


### PR DESCRIPTION
Expecting an absolute path removes any coupling with the the point of execution. This will enable tests and debugging while making the usage more clear. 